### PR TITLE
Dynamische interval op basis van MBs left

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Odido Unlimited Auto Bundle Requester
 
 ### Without needing to sniff your URL every month.
-It runs every 5 mins (can be set with ENV variable `UPDATE_INTERVAL`), and requests new bundle when MB's is less than 2000.
+It runs every 10, 2 or 0.5 mins (can be set with ENV variables), and requests new bundle when MB's is less than 2000.
 Firstly a login token is retrieved via the "regular" log in URL, from which a Bearer token is retrieved.
 With the Bearer token the regular API is used to request: current bundles, how much is left on these bundles and then (when needed) a new bundle is requested.
 Every request is retried at least 10 times when a request fails.
@@ -29,6 +29,12 @@ To select a different bundle:
 3. Next, review the available bundles in the logs to determine the correct bundle code.
 4. Once you've identified the desired bundle code, update the `BUYINGCODE` environment variable with the new code.
 
+### Configure intervales
+Based on the amount of MBs left, the intervals do change.
+* More than 10GB available, default interval is 10 min. (Overwrite via env var `UPDATE_INTERVAL_HIGH`)
+* Less than 10GB available, default interval is 2 min. (Overwrite via env var `UPDATE_INTERVAL_MEDIUM`)
+* Less than 2GB available, default interval is 0.5 min. (Overwrite via env var `UPDATE_INTERVAL_LOW`)
+
 ### Node.js with Yarn/NPM
 1. `git clone https://github.com/lodu/TMobile-NL-Unlimited-Bundle-Automated`
 2. `yarn` or `npm install`
@@ -36,7 +42,9 @@ To select a different bundle:
       ```bash
       AUTHORIZATIONTOKEN=xxxxxxxxxx
       MSISDN=+3161234567890
-      UPDATE_INTERVAL=5
+      UPDATE_INTERVAL_HIGH=10
+      UPDATE_INTERVAL_MEDIUM=2
+      UPDATE_INTERVAL_LOW=0.5
       BUYINGCODE=A0DAY01
       DEBUG=0
       ```
@@ -50,7 +58,9 @@ To select a different bundle:
       ```bash
       AUTHORIZATIONTOKEN=xxxxxxxxxx
       MSISDN=+3161234567890
-      UPDATE_INTERVAL=5
+      UPDATE_INTERVAL_HIGH=10
+      UPDATE_INTERVAL_MEDIUM=2
+      UPDATE_INTERVAL_LOW=0.5
       BUYINGCODE=A0DAY01
       DEBUG=0
       ```
@@ -62,7 +72,9 @@ To select a different bundle:
       ```bash
       AUTHORIZATIONTOKEN=xxxxxxxxxx
       MSISDN=+3161234567890
-      UPDATE_INTERVAL=5
+      UPDATE_INTERVAL_HIGH=10
+      UPDATE_INTERVAL_MEDIUM=2
+      UPDATE_INTERVAL_LOW=0.5
       BUYINGCODE=A0DAY01
       DEBUG=0
       ```
@@ -75,7 +87,9 @@ To select a different bundle:
    ```bash
    AUTHORIZATIONTOKEN=xxxxxxxxxx
    MSISDN=+3161234567890
-   UPDATE_INTERVAL=5
+   UPDATE_INTERVAL_HIGH=10
+   UPDATE_INTERVAL_MEDIUM=2
+   UPDATE_INTERVAL_LOW=0.5
    BUYINGCODE=A0DAY01
    DEBUG=0
    ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 
-import {checkENVs, getDynamicInterval} from "./utils"; // Removed getInterval import since we will define our own logic
+import {checkENVs, getDynamicInterval} from "./utils";
 
 import TMobile from "./providerModels/TMobile";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 
-import { checkENVs, getInterval } from "./utils";
+import {checkENVs, getDynamicInterval} from "./utils"; // Removed getInterval import since we will define our own logic
 
 import TMobile from "./providerModels/TMobile";
 
@@ -18,8 +18,13 @@ const run = async () => {
   if (MBsLeft < 2000) {
     tmobile.requestBundle();
   }
+  return MBsLeft;
 };
-run()
-setInterval(() => {
-  run();
-}, getInterval());
+
+const executeWithDynamicInterval = async () => {
+  const MBsLeft = await run();
+  const interval = getDynamicInterval(MBsLeft);
+  setTimeout(executeWithDynamicInterval, interval);
+};
+
+executeWithDynamicInterval();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,14 +63,41 @@ export function checkENVs() {
   }
 }
 
-// When ENV-variable is not set return 5
-export function getInterval(): number {
-  const interval: number = isNaN(parseInt(process.env.UPDATE_INTERVAL || ""))
-    ? 5
-    : parseInt(process.env.UPDATE_INTERVAL);
+function getInterval(type: 'low' | 'medium' | 'high'): number {
+  let intervalEnvVar: string | undefined;
+  let defaultInterval: number;
+
+  switch (type) {
+    case 'low':
+      intervalEnvVar = process.env.UPDATE_INTERVAL_LOW;
+      defaultInterval = 0.5; // 0.5 minutes
+      break;
+    case 'medium':
+      intervalEnvVar = process.env.UPDATE_INTERVAL_MEDIUM;
+      defaultInterval = 2; // 2 minutes
+      break;
+    case 'high':
+      intervalEnvVar = process.env.UPDATE_INTERVAL_HIGH;
+      defaultInterval = 10; // 10 minutes
+      break;
+    default:
+      throw new Error(`Unknown interval type: ${type}`);
+  }
+
+  const interval: number = isNaN(parseFloat(intervalEnvVar || "")) ? defaultInterval : parseFloat(intervalEnvVar);
   return minsToMs(interval);
 }
 
 function minsToMs(minutes: number): number {
   return minutes * 1000 * 60;
+}
+
+export function getDynamicInterval(MBsLeft: number): number {
+  if (MBsLeft < 2000) {
+    return getInterval('low');
+  } else if (MBsLeft < 10000) {
+    return getInterval('medium');
+  } else {
+    return getInterval('high');
+  }
 }


### PR DESCRIPTION
Als je tegen de limiet aanzit, dan wil je eigenlijk dat de interval beduidend korter is, dan op momenten waarin je heel erg ver van de limiet ziet. 

Heb je meer dan 10GB beschikbaar: hoge interval tijd (standaard 10 minuten)
Heb je minder dan 10GB beschikbaar: medium interval (standaard 2 minuten)
Heb je minder dan 2GB: low interval (30 seconden).

Docker image beschikbaar via https://hub.docker.com/repository/docker/renkosteenbeek/odido